### PR TITLE
failure when using filter_var with booleans

### DIFF
--- a/solusvm/solusvm_client.php
+++ b/solusvm/solusvm_client.php
@@ -375,7 +375,7 @@ class SolusVMClient {
                 throw new Exception("Invalid IPv4 Address");
             }
 
-            if(filter_var($forceaddip, FILTER_VALIDATE_BOOLEAN) === false) {
+            if(filter_var($forceaddip, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === NULL) {
                 throw new Exception("forceaddip must be boolean");
             }
 
@@ -440,7 +440,7 @@ class SolusVMClient {
             throw new Exception("Invalid ServerID");
         }
 
-        if(filter_var($changeHDD, FILTER_VALIDATE_BOOLEAN) === false) {
+        if(filter_var($changeHDD, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === NULL) {
             throw new Exception("changeHDD must be boolean");
         }
 
@@ -462,7 +462,7 @@ class SolusVMClient {
             throw new Exception("Invalid ServerID");
         }
 
-        if(filter_var($deleteclient, FILTER_VALIDATE_BOOLEAN) === false) {
+        if(filter_var($deleteclient, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === NULL) {
             throw new Exception("deleteclient must be boolean");
         }
 


### PR DESCRIPTION
filter_var returns the filtered data or false if the filter fails. For boolean data we should use FILTER_NULL_ON_FAILURE and check against NULL
